### PR TITLE
Fix zero value color bug

### DIFF
--- a/src/components/plot-layouts/PCPlot/PCPlot.vue
+++ b/src/components/plot-layouts/PCPlot/PCPlot.vue
@@ -245,7 +245,7 @@ function getPlotXBounds () {
 
 function getLineColor (dataPoint) {
 	if (!settings.colorScaleCategory) return "black"
-	if (!dataPoint[settings.colorScaleCategory]) return "black"
+	if (dataPoint[settings.colorScaleCategory] === null || dataPoint[settings.colorScaleCategory] === undefined) return "black"
 	return settings.colorScale(dataPoint[settings.colorScaleCategory])
 }
 


### PR DESCRIPTION
Made check for non-value more explicit. "0" is now a valid value for color calculation.