### PR TITLE
Re-enable SVG exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md-analysis-cli",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/plot-layouts/ScatterPlot/ScatterPlot.vue
+++ b/src/components/plot-layouts/ScatterPlot/ScatterPlot.vue
@@ -286,6 +286,9 @@ function handleExportRequest (format) {
     if (format === 'png') {
 		exportPNG()
 	} 
+    else if (format === 'svg') {
+        exportSVG()
+    }
 	else {
 		throw new Error('Unknown format in export request')
 	}
@@ -294,6 +297,23 @@ function handleExportRequest (format) {
 function exportPNG () {
 	const csvElement = plotCanvas.value
 	saveSvgAsPng(csvElement, 'ScatterPlot.png', {encoderOptions: 1, backgroundColor: 'white', scale: 2})
+}
+
+function exportSVG () {
+    const csvElement = plotCanvas.value
+	var svgData = csvElement.innerHTML 
+	var head = '<svg title="graph" version="1.1" xmlns="http://www.w3.org/2000/svg">'
+	
+	let style = `<style>`
+	style += 'svg {font-family: monospace;}'
+	style += '.scatter-container text {font-size: 0.8rem; text-anchor: middle; dominant-baseline: middle;}'
+	style += '.scatter-container line {stroke: black; fill-opacity: 0;}'
+    style += '.tick-y text { text-anchor: end; }'
+    style += '.tick-ub { dominant-baseline: hanging; }'
+	style += '</style>'
+	var full_svg = head +  style + svgData + "</svg>"
+	var blob = new Blob([full_svg], {type: "image/svg+xml"});  
+	saveAs(blob, "ScatterPlot.svg");
 }
 
 </script>

--- a/src/components/tools/ExportForm.vue
+++ b/src/components/tools/ExportForm.vue
@@ -6,6 +6,7 @@
                 <span>Format: </span>
                 <select ref="formatSelector">
                     <option value="png">Image (PNG)</option>
+                    <option value="svg">Vector graphics (SVG)</option>
                 </select>
             </div>
             <div class="d-grid gap-2 mt-2">


### PR DESCRIPTION
SVG exports were disabled in 1.6.0 due to the introduction of rasterized rendering, and because the SVG export code is difficult to maintain. However, it has been reintroduced as it has been requested by some users.

Export to SVG when using rasterized rendering is disabled due to alignment issues (also, SVG exports when using rasterized rendering is a bit pointless). Attempting to export to SVG when using rasterized rendering will result in a warning.