### PR TITLE
Hide range indicator if data is categorical

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md-analysis-cli",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "private": true,
   "author": {
     "name": "Julian Martinsson Bonde",

--- a/src/components/plot-features/RangeIndicator.vue
+++ b/src/components/plot-features/RangeIndicator.vue
@@ -1,5 +1,5 @@
 <template>
-    <g v-if="column" class="range-indicator">
+    <g v-if="column && showColorCodeLegend" class="range-indicator">
         <text 
             :style="{fontSize: `${optionsStore.titleSize}em`}"
             class="title"
@@ -21,7 +21,7 @@
                 :fill="color" 
                 :y="barHeight*resolution - (index+1) * barHeight" 
                 :width="barWidth" 
-                :height="barHeight"
+                :height="barHeight"    
             />
 
             <text 
@@ -37,36 +37,36 @@
 </template>
 
 <script setup>
-import {computed} from "vue"
-import { storeToRefs } from "pinia"
+import { computed } from "vue";
+import { storeToRefs } from "pinia";
 
-import {linspace} from "@/utils/data-utils"
-import {useOptionsStore} from "../../store/OptionsStore"
-import {useDataStore} from "../../store/DataStore"
+import { linspace } from "@/utils/data-utils";
+import { useOptionsStore } from "../../store/OptionsStore";
 
-const optionsStore = useOptionsStore()
-const {colorCodeUpperBound, colorCodeLowerBound} = storeToRefs(optionsStore)
-const dataStore = useDataStore()
-const {data} = storeToRefs(dataStore)
+const optionsStore = useOptionsStore();
+const {colorCodeUpperBound, colorCodeLowerBound, showColorCodeLegend} = storeToRefs(optionsStore);
 
-const resolution = 30
-const barWidth = 20
-const barHeight = 4
-const tickMargin = 8
+const resolution = 30;
+const barWidth = 20;
+const barHeight = 4;
+const tickMargin = 8;
 
 const column = computed(() => {
-    return optionsStore.getActiveColorCodeColumn()
+    // Ignore if data is categorical
+    const c = optionsStore.getActiveColorCodeColumn();
+    if (c && c.usesCategoricalData) return null;
+    return optionsStore.getActiveColorCodeColumn();
 })
 
 const spectrumArray = computed(() => {
-    if (!column.value) return []
+    if (!column.value) return [];
     
-    let linearScale = linspace(colorCodeLowerBound.value, colorCodeUpperBound.value, resolution)
-    let colorScale = []
+    let linearScale = linspace(colorCodeLowerBound.value, colorCodeUpperBound.value, resolution);
+    let colorScale = [];
     for (let value of linearScale) {
-        colorScale.push(optionsStore.getSampleColorWithValue(value))
+        colorScale.push(optionsStore.getSampleColorWithValue(value));
     }
-    return colorScale
+    return colorScale;
 })
 
 

--- a/src/components/sidemenu/analysis/ColorCodeForm.vue
+++ b/src/components/sidemenu/analysis/ColorCodeForm.vue
@@ -14,7 +14,7 @@
                     <option v-for="c in categories" :key="c.id" :value="c"> {{ c.displayTitle }}</option>
                 </select>
             </div>
-            <div class="control-group" title="If enabled, data points will be color coded based on input similarity (euclidean proximity).">
+            <div class="control-group" title="If enabled, data points will be color-coded based on input similarity (euclidean proximity).">
                 <div style="display: flex; justify-content: space-between; flex-direction: row;">
                     <label class="form-check-label m-0">
                         Use similarity color coding
@@ -26,22 +26,33 @@
                     >
                 </div>
             </div>
+
+            <div class="control-group" title="If enabled, the plot will display a color code indicator.">
+                <div style="display: flex; justify-content: space-between; flex-direction: row;">
+                    <label class="form-check-label m-0">
+                        Show color code legend
+                    </label>
+                    <input
+                        v-model="showColorCodeLegend"
+                        type="checkbox" 
+                    >
+                </div>
+            </div>
         </div>
     </SidebarSection>
 </template>
 
 <script setup>
-import { ref } from "vue"
-import { storeToRefs } from "pinia"
-import SidebarSection from "@/components/layouts/SidebarSection"
-import {useOptionsStore} from "@/store/OptionsStore"
-import {useDataStore} from "@/store/DataStore"
+import { storeToRefs } from "pinia";
+import SidebarSection from "@/components/layouts/SidebarSection";
+import {useOptionsStore} from "@/store/OptionsStore";
+import {useDataStore} from "@/store/DataStore";
 
-const optionsStore = useOptionsStore()
-const dataStore = useDataStore()
+const optionsStore = useOptionsStore();
+const dataStore = useDataStore();
 
-const {selectedColorCodeCategory, useSimilarityColorCoding} = storeToRefs(optionsStore)
-const {categories} = storeToRefs(dataStore)
+const {selectedColorCodeCategory, useSimilarityColorCoding, showColorCodeLegend} = storeToRefs(optionsStore);
+const {categories} = storeToRefs(dataStore);
 
 const props = defineProps({
     startMaximized: {
@@ -51,11 +62,11 @@ const props = defineProps({
 })
 
 function onColorCategoryChange (evt) {
-    optionsStore.resetColorCodeOverride()
+    optionsStore.resetColorCodeOverride();
 }
 
 function onUseSimilarityColorCodingChange (evt) {
-    optionsStore.resetColorCodeOverride()
+    optionsStore.resetColorCodeOverride();
 }
 
 </script>

--- a/src/store/OptionsStore.js
+++ b/src/store/OptionsStore.js
@@ -17,6 +17,7 @@ export const useOptionsStore = defineStore('options', {
         colorCodeUpperBound: null,
         colorCodeLowerBound: null,
         useSimilarityColorCoding: true,
+        showColorCodeLegend: true,
 
         // PCP lines
         includedDataOpacity: 1,

--- a/src/store/StateStore.js
+++ b/src/store/StateStore.js
@@ -22,7 +22,6 @@ export const useStateStore = defineStore('state', {
     getters: {},
     actions: {
         queueReRenders () {
-            console.log("QUEUE RERENDER")
             this.reRenderMvGrid = true
         },
         setView(view) {


### PR DESCRIPTION
- Hides range indicator if data is categorical
- Adds option to hide range indicator (aka "legend") in the color coding menu
- Removes pointless console log
- Bumps version to 1.13.3

closes #74 